### PR TITLE
new way to modify Translate Type

### DIFF
--- a/actions/html_side1.php
+++ b/actions/html_side1.php
@@ -25,7 +25,7 @@ function create_side($filename) {
             ['id' => 'process', 'admin' => 0, 'href' => 'process', 'title' => 'In process'],
             ['id' => 'Pending', 'admin' => 0, 'href' => 'Pending', 'title' => 'In process (total)'],
             ['id' => 'add', 'admin' => 1, 'href' => 'add', 'title' => 'Add'],
-            ['id' => 'translate_type', 'admin' => 1, 'href' => 'translate_type', 'title' => 'Translate Type'],
+            ['id' => 'tt_load', 'admin' => 1, 'href' => 'tt/load', 'title' => 'Translate Type'],
         ],
         'Users' => [
             ['id' => 'Emails', 'admin' => 1, 'href' => 'Emails', 'title' => 'Emails'],

--- a/coordinator/admin/qids/load.php
+++ b/coordinator/admin/qids/load.php
@@ -84,8 +84,6 @@ $qua = (in_array($dis, $quaries)) ? $quaries['all'] : $quaries[$dis];
 //---
 $qq = execute_query($qua);
 //---
-$numb = 0;
-//---
 function make_row($id, $title, $qid, $numb) {
 	$edit_icon = make_edit_icon($id, $title, $qid);
     //---
@@ -112,6 +110,8 @@ function make_row($id, $title, $qid, $numb) {
 	HTML;
 }
 //---
+$numb = 0;
+//---
 foreach ( $qq AS $Key => $table ) {
 	$numb += 1;
 	$id 	= $table['id'];
@@ -135,7 +135,7 @@ echo <<<HTML
 	</tbody>
 	</table>
 
-<form action="coordinator.php?ty=qids/post&nonav=1" method="POST">
+<form action="coordinator.php?ty=qids/post" method="POST">
 	$testin
 	<input name='ty' value="qids/post" hidden/>
 	<div id='qidstab' style='display: none;'>
@@ -153,13 +153,14 @@ echo <<<HTML
 		</table>
 	</div>
 	<span role='button' id="add_row" class="btn btn-info" style="position: absolute; right: 130px;" onclick='add_row()'>New row</span>
-	<button type="submit" class="btn btn-success">Submit</button>
+	<button id="submit_bt" type="submit" class="btn btn-success" style='display: none;'>Submit</button>
 </form>
 HTML;
 ?>
 <script type="text/javascript">
 var i = 1;
 function add_row() {
+	$('#submit_bt').show();
 	$('#qidstab').show();
 	var ii = $('#tab_new >tr').length + 1;
 	var e = "<tr>";

--- a/coordinator/admin/tt/edit_translate_type.php
+++ b/coordinator/admin/tt/edit_translate_type.php
@@ -1,0 +1,130 @@
+<?php
+//---
+if (user_in_coord == false) {
+	echo "<meta http-equiv='refresh' content='0; url=index.php'>";
+	exit;
+};
+//---
+?>
+</div>
+<script> 
+    $('#mainnav').hide();
+    $('#maindiv').hide();
+</script>
+<div class="container-fluid">
+<?PHP
+//---
+if (isset($_REQUEST['test'])) {
+	ini_set('display_errors', 1);
+	ini_set('display_startup_errors', 1);
+	error_reporting(E_ALL);
+};
+//---
+include_once 'functions.php';
+//---
+$tabs = array();
+//---
+$title  = $_REQUEST['title'] ?? '';
+$lead    = $_REQUEST['lead'] ?? '';
+$full    = $_REQUEST['full'] ?? '';
+$id     = $_REQUEST['id'] ?? '';
+//---
+echo <<<HTML
+<div class='card'>
+    <div class='card-header'>
+        <h4>Edit Translate type</h4>
+    </div>
+    <div class='card-body'>
+HTML;
+//---
+function send_qid($id, $title, $lead, $full) {
+    //---
+    insert_to_translate_type($title, $lead, $full, $tt_id=$id);
+    //---
+    // green text success
+    echo <<<HTML
+        <div class='alert alert-success' role='alert'>Translate type updated<br>
+            window will close in 3 seconds            
+        </div>
+        <!-- close window after 3 seconds -->
+        <script>
+            setTimeout(function() {
+                window.close();
+            }, 3000);
+        </script>
+    HTML;
+}
+//---
+function echo_form($title, $lead, $full, $id) {
+	$lead_checked = ($lead == 1 || $lead == "1") ? 'checked' : '';
+	$full_checked = ($full == 1 || $full == "1") ? 'checked' : '';
+    //---
+    echo <<<HTML
+        <form action='coordinator.php?ty=tt/edit_translate_type&nonav=120' method='POST'>
+            <input name='edit' value="1" hidden/>
+            <div class='container'>
+                <div class='row'>
+                    <div class='col-md-3'>
+                        <div class='input-group mb-3'>
+                            <div class='input-group-prepend'>
+                                <span class='input-group-text'>Id</span>
+                            </div>
+                            <input class='form-control' type='text'value='$id' disabled/>
+                            <input class='form-control' type='text' id='id' name='id' value='$id' hidden/>
+                        </div>
+                    </div>
+                    <div class='col-md-3'>
+                        <div class='input-group mb-3'>
+                            <div class='input-group-prepend'>
+                                <span class='input-group-text'>Title</span>
+                            </div>
+                            <input class='form-control' type='text' id='title' name='title' value='$title' required/>
+                        </div>
+                    </div>
+                    <div class='col-md-3'>
+                        <div class='row'>
+                            <div class='col'>
+                                <div class='input-group mb-3'>
+                                    <div class='input-group-prepend'>
+                                        <span class='input-group-text'>Lead</span>
+                                    </div>
+                                    <div class='form-check form-switch'>
+                                        <input type='hidden' name='lead' value='0'>
+                                        <input class='form-check-input' type='checkbox' name='lead' value='1' $lead_checked>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class='col'>
+                                <div class='input-group mb-3'>
+                                    <div class='input-group-prepend'>
+                                        <span class='input-group-text'>Full</span>
+                                    </div>
+                                    <div class='form-check form-switch'>
+                                        <input type='hidden' name='full' value='0'>
+                                        <input class='form-check-input' type='checkbox' name='full' value='1' $full_checked>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class='col-md-2'>
+                        <input class='btn btn-primary' type='submit' value='send'/>
+                    </div>
+                </div>
+            </div>
+        </form>
+    HTML;
+}
+//---
+if ( isset($_REQUEST['edit']) ) {
+    send_qid($id, $title, $lead, $full);
+    //---
+} else {
+    echo_form($title, $lead, $full, $id);
+}
+//---
+echo <<<HTML
+    </div>
+</div>
+HTML;
+//---

--- a/coordinator/admin/tt/load.php
+++ b/coordinator/admin/tt/load.php
@@ -1,0 +1,230 @@
+<?php
+//---
+/*
+
+INSERT INTO translate_type (tt_title, tt_lead, tt_full) SELECT DISTINCT q.title, 1, 0 from qids q 
+	WHERE q.title not in (SELECT tt_title FROM translate_type)
+
+*/
+//---
+require 'getcats.php';
+include_once 'functions.php';
+//---
+$cat = $_REQUEST['cat'] ?? 'RTTILAE';
+$testin = (($_REQUEST['test'] ?? '') != '') ? "<input name='test' value='1' hidden/>" : "";
+//---
+function filter_stat($cat) {
+	global $cat_to_camp;
+	// array keys
+	$cats_titles = array_keys($cat_to_camp);
+	//---
+	$d33 = <<<HTML
+		<div class="input-group">
+			<span class="input-group-text">%s</span>
+			%s
+		</div>
+	HTML;
+	//---
+	$y1 = makeDropdown($cats_titles, $cat, 'cat', 'All');
+	$uuu = sprintf($d33, 'Category:', $y1);
+	//---
+    return $uuu;
+}
+//---
+$uuu = filter_stat($cat);
+//---
+$new_titles = array();
+$full_translates_tab = array();
+//---
+$translate_type_sql = <<<SQL
+    SELECT tt_id, tt_title, tt_lead, tt_full
+	FROM translate_type
+SQL;
+//---
+foreach ( execute_query($translate_type_sql) AS $k => $tab ) {
+	$full_translates_tab[$tab['tt_title']] = ['id' => $tab['tt_id'], 'lead' => $tab['tt_lead'], 'full' => $tab['tt_full']];
+}
+//---
+$cat_titles = array();
+//---
+if ($cat == 'All') {
+	foreach ( execute_query('SELECT DISTINCT title from qids WHERE title not in (SELECT tt_title FROM translate_type)') AS $Key => $gg ) {
+		if (!in_array($gg['title'], $full_translates_tab)) {
+			$new_titles[] = $gg['title'];
+		}
+	};
+	$cat_titles = array_keys($full_translates_tab);
+} else {
+	$cat_titles = get_mdwiki_cat_members($cat, $use_cash=true, $depth=1);
+}
+//---
+echo <<<HTML
+	<script>$('#tt_load').addClass('active');</script>
+	<div class='card-header'>
+		<form action="coordinator.php?ty=tt/load" method="GET">
+			$testin
+			<input name='ty' value="tt/load" hidden/>
+			<div class='row'>
+				<div class='col-md-3'>
+					<h4>Translate Type:</h4>
+				</div>
+				<div class='col-md-3'>
+					$uuu
+				</div>
+				<div class='aligncenter col-md-2'><input class='btn btn-primary' type='submit' name='start' value='Filter' /></div>
+			</div>
+		</form>
+	</div>
+	<div class='card-body'>
+	<table id='em' class='table table-striped compact table-mobile-responsive table-mobile-sided'>
+		<thead>
+			<tr>
+				<th>#</th>
+				<th>id</th>
+				<th>Title</th>
+				<th>Lead</th>
+				<th>Full</th>
+				<th>Edit</th>
+			</tr>
+		</thead>
+		<tbody id="tab_ma">
+	HTML;
+//---
+function make_edit_icon($id, $title, $full, $lead) {
+	//---
+    $edit_params = array(
+		'id'   => $id,
+		'title'  => $title,
+		'nonav'  => 1,
+		'lead'  => $lead,
+		'full'  => $full
+	);
+    //---
+    $edit_url = "coordinator.php?ty=tt/edit_translate_type&" . http_build_query( $edit_params );
+    //---
+	$onclick = 'pupwindow1("' . $edit_url . '")';
+    //---
+    return <<<HTML
+    	<a class='btn btn-primary btn-sm' onclick='$onclick'>Edit</a>
+    HTML;
+}
+//---
+function make_row($id, $title, $lead, $full, $numb) {
+	$edit_icon = make_edit_icon($id, $title, $full, $lead);
+    //---
+	$md_title = make_mdwiki_title($title);
+    //---
+	$lead_checked = ($lead == 1 || $lead == "1") ? 'checked' : '';
+	$full_checked = ($full == 1 || $full == "1") ? 'checked' : '';
+    //---
+	return <<<HTML
+	<tr>
+		<th data-content="#" data-sort="$numb">
+			$numb
+		</th>
+		<th data-content="#" data-sort="$id">
+			$id
+		</th>
+		<td data-content="title" data-sort="$title">
+			$md_title
+		</td>
+		<td data-content='Lead' data-sort='$lead'>
+			<div class='form-check form-switch'>
+				<input class='form-check-input' type='checkbox' name='lead_$numb' value='1' $lead_checked disabled>
+			</div>
+		</td>
+		<td data-content='Full' data-sort='$full'>
+			<div class='form-check form-switch'>
+				<input class='form-check-input' type='checkbox' name='full_$numb' value='1' $full_checked disabled>
+			</div>
+		</td>
+		<td data-content="Edit">
+			$edit_icon
+		</td>
+	</tr>
+	HTML;
+}
+//---
+$numb = 0;
+//---
+foreach ( $cat_titles as $title ) {
+	//---
+	if (in_array($title, $new_titles)) continue;
+	//---
+	$numb += 1;
+	//---
+	$table = $full_translates_tab[$title] ?? [];
+	//---
+	$id			= $table['id'] ?? '';
+	$lead 		= $table['lead'] ?? 1;
+	$full		= $table['full'] ?? 0;
+    //---
+	echo make_row($id, $title, $lead, $full, $numb);
+	//---
+};
+//---
+echo <<<HTML
+		</tbody>
+	</table>
+
+	<form action="coordinator.php?ty=tt/post" method="POST">
+	$testin
+	<input name='ty' value="tt/post" hidden/>
+	<div id='tt_table' class="form-group" style='display: none;'>
+		<table class='table table-striped compact table-mobile-responsive table-mobile-sided' style='width: 90%;'>
+			<thead>
+				<tr>
+					<th>#</th>
+					<th>Title</th>
+					<th>Lead</th>
+					<th>Full</th>
+				</tr>
+			</thead>
+			<tbody id="tab_new">
+
+			</tbody>
+		</table>
+	</div>
+	<span role='button' id="add_row" class="btn btn-info" style="position: absolute; right: 130px;" onclick='add_row()'>New row</span>
+	<button id="submit_bt" type="submit" class="btn btn-success" style='display: none;'>Submit</button>
+</form>
+HTML;
+?>
+<script type="text/javascript">
+	var i = 1;
+	function add_row() {
+		$('#submit_bt').show();
+		$('#tt_table').show();
+		var ii = $('#tab_new >tr').length + 1;
+		var e = "<tr>";
+		e = e + "<td>" + ii + "</td>";
+		e = e + "<input type='hidden' name='add[]" + ii + "'/>";
+		e = e + "<td><input name='title[]" + ii + "'/></td>";
+
+		e = e + "<td data-content='Lead'><div class='form-check form-switch'>";
+		e = e + "<input type='text' name='lead[]" + ii + "' value='0'/>";
+		// e = e + "<input size='2' class='form-check-input' type='checkbox' name='lead[]" + ii + "' value='1'>";
+		e = e + "</div></td>";
+
+		e = e + "<td data-content='Full'><div class='form-check form-switch'>";
+		e = e + "<input type='text' name='full[]" + ii + "' value='0'/>";
+		// e = e + "<input size='2' class='form-check-input' type='checkbox' name='full[]" + ii + "' value='1'>";
+		e = e + "</div></td>";
+
+		e = e + "</tr>";
+		$('#tab_new').append(e);
+		i++;
+	};
+
+	$(document).ready( function () {
+		var t = $('#em').DataTable({
+		// order: [[5	, 'desc']],
+		// paging: false,
+		lengthMenu: [[50, 100, 150], [50, 100, 150]],
+		// scrollY: 800
+		});
+	} );
+
+</script>
+
+</div>

--- a/coordinator/admin/tt/post.php
+++ b/coordinator/admin/tt/post.php
@@ -1,0 +1,43 @@
+<?php
+//---
+if (isset($_POST['se'])) {
+	// echo "<pre>" . var_export($_POST, true) . "</pre>";
+    $se   = $_POST['se'];
+    foreach ($se as $index => $n) {
+        //---
+        $id       = $_POST["id_$n"] ?? '';
+        $title    = $_POST["title_$n"] ?? '';
+        $lead     = $_POST["lead_$n"] ?? '';
+        $full     = $_POST["full_$n"] ?? '';
+        //---
+        if ($title == '') continue;
+        //---
+        $re = insert_to_translate_type($title, $lead, $full, $tt_id=$id);
+		//---
+		// echo "<br>added: title: $title, lead: $lead, full: $full";
+		//---
+    }
+}
+//---
+if (isset($_POST['add'])) {
+	// var_export($_POST['add']);
+	for($i = 0; $i < count($_POST['add']); $i++ ){
+		//---
+		$title 	= $_POST['title'][$i] ?? '';
+		$lead 	= $_POST['lead'][$i] ?? 0;
+		$full 	= $_POST['full'][$i] ?? 0;
+		//---
+        if ($title == '') continue;
+        //---
+        $re = insert_to_translate_type($title, $lead, $full);
+		//---
+	};
+};
+//---
+echo <<<HTML
+	<div class='alert alert-success' role='alert'>Translate Type Saved...<br>
+		return to Translate Type page in 2 seconds
+	</div>
+	<meta http-equiv='refresh' content='2; url=coordinator.php?ty=tt/load'>
+HTML;
+//---


### PR DESCRIPTION
Providing a new way to modify Translate Type due to the problem of not saving modifications when sending them in the old way, which includes about 2,900 addresses and 3 entries for each address, which causes the transmission to be aborted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new link for loading translation types in the interface.
	- Enhanced translation type management with capabilities for filtering, editing, and adding new types.
- **Improvements**
	- Updated the handling and display of translation types, improving user interaction.
	- Improved form handling for editing translation type details.
- **Bug Fixes**
	- Fixed an issue with variable scope in the `make_row` function.
	- Adjusted visibility settings for the submit button to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->